### PR TITLE
更新%csl.log的回复

### DIFF
--- a/commspt_bot_avilla/modules/simple_response.py
+++ b/commspt_bot_avilla/modules/simple_response.py
@@ -85,8 +85,12 @@ register(
 
 register(
     "csl.log",
-    """请您查看下面的链接，将 CustomSkinLoader 日志文件直接发送至群内。
-👉🏻 https://manual.littlesk.in/problems#customskinloader""",
+    """CustomSkinLoader 的日志位于 .minecraft/CustomSkinLoader/CustomSkinLoader.log，
+
+在使用版本隔离的情况下则为 .minecraft/versions/{versions}/CustomSkinLoader/CustomSkinLoader.log
+请将 CustomSkinLoader 日志文件直接发送至群内。
+
+文档地址:https://manual.littlesk.in/problems#customskinloader""",
 )
 
 register(

--- a/commspt_bot_avilla/modules/simple_response.py
+++ b/commspt_bot_avilla/modules/simple_response.py
@@ -90,7 +90,7 @@ register(
 在使用版本隔离的情况下则为 .minecraft/versions/{versions}/CustomSkinLoader/CustomSkinLoader.log
 请将 CustomSkinLoader 日志文件直接发送至群内。
 
-文档地址:https://manual.littlesk.in/problems#customskinloader""",
+详细 👉 https://manual.littlesk.in/problems#customskinloader""",
 )
 
 register(


### PR DESCRIPTION
暂时没有经过测试(没有运行环境)
麻烦开发者进行测试

原文:
CustomSkinLoader 的日志位于 .minecraft/CustomSkinLoader/CustomSkinLoader.log，

在使用版本隔离的情况下则为 .minecraft/versions/{versions}/CustomSkinLoader/CustomSkinLoader.log 请将 CustomSkinLoader 日志文件直接发送至群内。

文档地址:https://manual.littlesk.in/problems#customskinloader